### PR TITLE
fix sourcemap options

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ function terser(userOptions = {}) {
     throw Error("sourceMap option is removed, use sourcemap instead");
   }
 
+
   const minifierOptions = serialize(
     Object.assign({}, userOptions, {
-      sourceMap: userOptions.sourcemap !== false,
+      sourceMap: (typeof userOptions.sourcemap === 'object'?userOptions.sourcemap:  userOptions.sourcemap!== false),
       sourcemap: undefined,
       numWorkers: undefined
     })

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,20 @@ test("minify with sourcemaps", async () => {
   expect(result.map).toBeTruthy();
 });
 
+
+test("minify with sourcemap options", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/sourcemap.js",
+    plugins: [terser( {sourcemap: {
+        "filename":"",
+        "root":"http://foo.com/src",
+        "url":"foo.min.js.map"
+      }})]
+  });
+  const result = await bundle.generate({ format: "cjs", sourcemap: true});
+  expect(result.code).toMatch("//# sourceMappingURL=foo.min.js.map");
+});
+
 test("allow to disable source maps", async () => {
   const bundle = await rollup({
     input: "test/fixtures/sourcemap.js",


### PR DESCRIPTION
I think the last release drops the `sourceMappingURL` output.