### PR TITLE
Implementing "lave" as serializer for userOptions object

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function terser(userOptions = {}) {
   };
 
   for (let key of ["sourcemap", "numWorkers"]) {
-    if (Object.prototype.hasOwnProperty.call(normalizedOptions, key)) {
+    if (normalizedOptions.hasOwnProperty(key)) {
       delete normalizedOptions[key];
     }
   }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function terser(userOptions = {}) {
     }
   }
 
-  const minifierOptions = lave(
+  const serializedOptions = lave(
     normalizedOptions,
     { generate, format: "expression" }
   );
@@ -34,7 +34,7 @@ function terser(userOptions = {}) {
     },
 
     renderChunk(code) {
-      return this.worker.transform(code, minifierOptions).catch(error => {
+      return this.worker.transform(code, serializedOptions).catch(error => {
         const { message, line, col: column } = error;
         console.error(
           codeFrameColumns(code, { start: { line, column } }, { message })

--- a/index.js
+++ b/index.js
@@ -1,18 +1,27 @@
 const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
-const serialize = require("serialize-javascript");
+const { generate } = require("escodegen");
+const lave = require("lave");
 
 function terser(userOptions = {}) {
   if (userOptions.sourceMap != null) {
     throw Error("sourceMap option is removed, use sourcemap instead");
   }
 
-  const minifierOptions = serialize(
-    Object.assign({}, userOptions, {
-      sourceMap: userOptions.sourcemap !== false,
-      sourcemap: undefined,
-      numWorkers: undefined
-    })
+  const normalizedOptions = {
+    ...userOptions,
+    ...{ sourceMap: userOptions.sourcemap !== false }
+  };
+
+  for (let key of ["sourcemap", "numWorkers"]) {
+    if (Object.prototype.hasOwnProperty.call(normalizedOptions, key)) {
+      delete normalizedOptions[key];
+    }
+  }
+
+  const minifierOptions = lave(
+    normalizedOptions,
+    { generate, format: "expression" }
   );
 
   return {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "license": "MIT",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
+    "escodegen": "^1.11.0",
     "jest-worker": "^23.2.0",
-    "serialize-javascript": "^1.5.0",
+    "lave": "^1.1.10",
     "terser": "^3.8.2"
   },
   "peerDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -107,3 +107,26 @@ test("allow to pass not string values to worker", async () => {
     '"use strict";window.a=5,window.a<3&&console.log(4);\n'
   );
 });
+
+test("allow to method shorthand definitions to worker", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [
+      terser({
+        mangle: { properties: { regex: /^_/ } },
+        output: {
+          comments(node, comment) {
+            if (comment.type === "comment2") {
+              // multiline comment
+              return /@preserve|@license|@cc_on|^!/i.test(comment.value);
+            }
+            return false;
+          }
+        }
+      })]
+  });
+  const result = await bundle.generate({ format: "cjs" });
+  expect(result.code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+});

--- a/test/test.js
+++ b/test/test.js
@@ -126,7 +126,9 @@ test("allow to method shorthand definitions to worker", async () => {
       })]
   });
   const result = await bundle.generate({ format: "cjs" });
-  expect(result.code).toEqual(
+  expect(result.output).toHaveLength(1);
+  const [output] = result.output;
+  expect(output.code).toEqual(
     '"use strict";window.a=5,window.a<3&&console.log(4);\n'
   );
 });

--- a/transform.js
+++ b/transform.js
@@ -1,7 +1,7 @@
 const { minify } = require("terser");
 
 const transform = (code, optionsString) => {
-  const options = eval(`(${optionsString})`)
+  const options = eval(optionsString);
   const result = minify(code, options);
   if (result.error) {
     throw result.error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,18 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+escodegen@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
+  integrity sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 escodegen@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
@@ -1339,6 +1351,7 @@ esprima@^3.1.1, esprima@^3.1.3:
 estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2372,6 +2385,11 @@ kleur@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
 
+lave@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/lave/-/lave-1.1.10.tgz#062207652c5502d7c6ff096c9de3995401f634d5"
+  integrity sha1-BiIHZSxVAtfG/wlsneOZVAH2NNU=
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -3121,10 +3139,6 @@ semver@^5.4.1:
 semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
-
-serialize-javascript@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #12

As mentioned the lave module would transpile the user options object correctly with method shorthands of ES6.

I've added a test for this as well. Everything green.