### PR TITLE
fix: fix error when bundling multiple outputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,13 +15,18 @@ function terser(userOptions = {}) {
     })
   );
 
+  let numOfBundles = 0;
+
   return {
     name: "terser",
 
     renderStart() {
-      this.worker = new Worker(require.resolve("./transform.js"), {
-        numWorkers: userOptions.numWorkers
-      });
+      if (!this.worker) {
+        this.worker = new Worker(require.resolve("./transform.js"), {
+          numWorkers: userOptions.numWorkers
+        });
+      }
+      numOfBundles++;
     },
 
     renderChunk(code) {
@@ -35,11 +40,19 @@ function terser(userOptions = {}) {
     },
 
     generateBundle() {
-      this.worker.end();
+      numOfBundles--;
+      // we only want to end worker on the last bundle
+      if (numOfBundles == 0) {
+        this.worker.end();
+      }
     },
 
     renderError() {
-      this.worker.end();
+      numOfBundles--;
+      // we only want to end worker on the last bundle
+      if (numOfBundles == 0) {
+        this.worker.end();
+      }
     }
   };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,25 @@ test("minify via terser options", async () => {
   expect(result.map).toBeFalsy();
 });
 
+test("minify multiple outputs", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [terser()]
+  });
+
+  const [bundle1, bundle2] = await Promise.all([
+    bundle.generate({ format: "cjs" }),
+    bundle.generate({ format: "es" })
+  ]);
+
+  expect(bundle1.code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+  expect(bundle2.code).toEqual(
+    'window.a=5,window.a<3&&console.log(4);\n'
+  );
+});
+
 test("minify with sourcemaps", async () => {
   const bundle = await rollup({
     input: "test/fixtures/sourcemap.js",
@@ -69,6 +88,27 @@ test("throw error on terser fail", async () => {
       ]
     });
     await bundle.generate({ format: "esm" });
+    expect(true).toBeFalsy();
+  } catch (error) {
+    expect(error.toString()).toMatch(/Name expected/);
+  }
+});
+
+test("throw error on terser fail with multiple outputs", async () => {
+  try {
+    const bundle = await rollup({
+      input: "test/fixtures/failed.js",
+      plugins: [
+        {
+          renderChunk: () => ({ code: "var = 1" })
+        },
+        terser()
+      ]
+    });
+    await Promise.all([
+      bundle.generate({ format: "cjs" }),
+      bundle.generate({ format: "esm" })
+    ]);
     expect(true).toBeFalsy();
   } catch (error) {
     expect(error.toString()).toMatch(/Name expected/);


### PR DESCRIPTION
This fixes an error that occurs when multiple outputs are specified
for bundling.
Reason:
- jest-worker was not cleaned up properly

Fixes #5