### PR TITLE
#16, but using context and on-demand worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,18 @@ function terser(userOptions = {}) {
     { generate, format: "expression" }
   );
 
+  let numOfBundles = 0;
+
   return {
     name: "terser",
 
     renderStart() {
-      this.worker = new Worker(require.resolve("./transform.js"), {
-        numWorkers: userOptions.numWorkers
-      });
+      if (!this.worker) {
+        this.worker = new Worker(require.resolve("./transform.js"), {
+          numWorkers: userOptions.numWorkers
+        });
+      }
+      numOfBundles++;
     },
 
     renderChunk(code) {
@@ -44,11 +49,19 @@ function terser(userOptions = {}) {
     },
 
     generateBundle() {
-      this.worker.end();
+      numOfBundles--;
+      // we only want to end worker on the last bundle
+      if (numOfBundles == 0) {
+        this.worker.end();
+      }
     },
 
     renderError() {
-      this.worker.end();
+      numOfBundles--;
+      // we only want to end worker on the last bundle
+      if (numOfBundles == 0) {
+        this.worker.end();
+      }
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -19,49 +19,46 @@ function terser(userOptions = {}) {
     }
   }
 
-  const serializedOptions = lave(
-    normalizedOptions,
-    { generate, format: "expression" }
-  );
-
-  let numOfBundles = 0;
+  const serializedOptions = lave(normalizedOptions, {
+    generate,
+    format: "expression"
+  });
 
   return {
     name: "terser",
 
-    renderStart() {
+    renderChunk(code) {
       if (!this.worker) {
         this.worker = new Worker(require.resolve("./transform.js"), {
           numWorkers: userOptions.numWorkers
         });
+        this.numOfBundles = 0;
       }
-      numOfBundles++;
-    },
 
-    renderChunk(code) {
-      return this.worker.transform(code, serializedOptions).catch(error => {
-        const { message, line, col: column } = error;
-        console.error(
-          codeFrameColumns(code, { start: { line, column } }, { message })
-        );
-        throw error;
-      });
-    },
+      this.numOfBundles++;
 
-    generateBundle() {
-      numOfBundles--;
-      // we only want to end worker on the last bundle
-      if (numOfBundles == 0) {
-        this.worker.end();
-      }
-    },
+      const result = this.worker
+        .transform(code, serializedOptions)
+        .catch(error => {
+          const { message, line, col: column } = error;
+          console.error(
+            codeFrameColumns(code, { start: { line, column } }, { message })
+          );
+          throw error;
+        });
 
-    renderError() {
-      numOfBundles--;
-      // we only want to end worker on the last bundle
-      if (numOfBundles == 0) {
-        this.worker.end();
-      }
+      const handler = () => {
+        this.numOfBundles--;
+
+        if (this.numOfBundles === 0) {
+          this.worker.end();
+          this.worker = 0;
+        }
+      };
+
+      result.then(handler, handler);
+
+      return result;
     }
   };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -42,13 +42,13 @@ test("minify multiple outputs", async () => {
     bundle.generate({ format: "cjs" }),
     bundle.generate({ format: "es" })
   ]);
+  const [output1] = bundle1.output;
+  const [output2] = bundle2.output;
 
-  expect(bundle1.code).toEqual(
+  expect(output1.code).toEqual(
     '"use strict";window.a=5,window.a<3&&console.log(4);\n'
   );
-  expect(bundle2.code).toEqual(
-    'window.a=5,window.a<3&&console.log(4);\n'
-  );
+  expect(output2.code).toEqual("window.a=5,window.a<3&&console.log(4);\n");
 });
 
 test("minify with sourcemaps", async () => {
@@ -163,7 +163,8 @@ test("allow to method shorthand definitions to worker", async () => {
             return false;
           }
         }
-      })]
+      })
+    ]
   });
   const result = await bundle.generate({ format: "cjs" });
   expect(result.output).toHaveLength(1);


### PR DESCRIPTION
This takes #16 as a fix for #5, and swizzles it around such that renderChunk fully controls the lifecycle of the worker. Multiple chunks in one build will still use the same worker, and it avoid scenarios wherein renderStart is called and no bundle is ever generated.