### PR TITLE
Automatically set `module: true` for the `esm` format

### DIFF
--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -3,7 +3,7 @@
 exports[`works with code splitting 1`] = `
 Object {
   "chunk-1.js": Object {
-    "code": "var chunk1=\\"chunk-1\\";console.log(chunk1);
+    "code": "console.log(\\"chunk-1\\");
 ",
     "dynamicImports": Array [],
     "exports": Array [],
@@ -15,7 +15,7 @@ Object {
     "name": "chunk-1",
   },
   "chunk-2.js": Object {
-    "code": "var chunk2=\\"chunk-2\\";console.log(chunk2);
+    "code": "console.log(\\"chunk-2\\");
 ",
     "dynamicImports": Array [],
     "exports": Array [],

--- a/test/fixtures/plain-file.js
+++ b/test/fixtures/plain-file.js
@@ -1,2 +1,4 @@
+"use strict";
+
 const foo = 'bar';
 console.log(foo);

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,17 @@ test("minify multiple outputs", async () => {
   expect(output2.code).toEqual("window.a=5,window.a<3&&console.log(4);\n");
 });
 
+test("minify module", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/plain-file.js",
+    plugins: [terser()]
+  });
+  const result = await bundle.generate({ format: "esm" });
+  expect(result.output).toHaveLength(1);
+  const [output] = result.output;
+  expect(output.code).toEqual('console.log("bar");\n');
+});
+
 test("minify with sourcemaps", async () => {
   const bundle = await rollup({
     input: "test/fixtures/sourcemap.js",


### PR DESCRIPTION
Terser has a special option `module` for minifying ES modules:
> - `module` (default `false`) — Use when minifying an ES6 module. "use strict"
>   is implied and names can be mangled on the top scope. If `compress` or
>   `mangle` is enabled then the `toplevel` option will be enabled.

This change updates the plugin so that if the `"esm"` output format is detected, the `module` flag is turned on by default.

Since multiple output formats can be set, the serialized `minifierOptions` has been split into two separate variables - one for `format: 'es'` and one for other formats. The serialized versions are created lazily so that if only 1 format is used, only 1 variable will be set.

Thanks to this change, the `"works with code splitting"` test now creates smaller code since the strings can be inlined.