### PR TITLE
Fixing error "Unexpected token =>"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
-const { generate } = require("escodegen");
-const lave = require("lave");
+const serialize = require("serialize-javascript");
 
 function terser(userOptions = {}) {
   if (userOptions.sourceMap != null) {
@@ -33,10 +32,7 @@ function terser(userOptions = {}) {
         }
       }
 
-      const serializedOptions = lave(normalizedOptions, {
-        generate,
-        format: "expression"
-      });
+      const serializedOptions = serialize(normalizedOptions);
 
       const result = this.worker
         .transform(code, serializedOptions)

--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
-    "escodegen": "^1.11.0",
     "jest-worker": "^24.0.0",
-    "lave": "^1.1.10",
+    "serialize-javascript": "^1.6.1",
     "terser": "^3.14.1"
   },
   "peerDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -162,7 +162,33 @@ test("allow to pass not string values to worker", async () => {
   );
 });
 
-test("allow to method shorthand definitions to worker", async () => {
+test("allow classic function definitions passing to worker", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [
+      terser({
+        mangle: { properties: { regex: /^_/ } },
+        output: {
+          comments: function (node, comment) {
+            if (comment.type === "comment2") {
+              // multiline comment
+              return /@preserve|@license|@cc_on|^!/i.test(comment.value);
+            }
+            return false;
+          }
+        }
+      })
+    ]
+  });
+  const result = await bundle.generate({ format: "cjs" });
+  expect(result.output).toHaveLength(1);
+  const [output] = result.output;
+  expect(output.code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+});
+
+test("allow method shorthand definitions passing to worker", async () => {
   const bundle = await rollup({
     input: "test/fixtures/unminified.js",
     plugins: [
@@ -170,6 +196,32 @@ test("allow to method shorthand definitions to worker", async () => {
         mangle: { properties: { regex: /^_/ } },
         output: {
           comments(node, comment) {
+            if (comment.type === "comment2") {
+              // multiline comment
+              return /@preserve|@license|@cc_on|^!/i.test(comment.value);
+            }
+            return false;
+          }
+        }
+      })
+    ]
+  });
+  const result = await bundle.generate({ format: "cjs" });
+  expect(result.output).toHaveLength(1);
+  const [output] = result.output;
+  expect(output.code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+});
+
+test("allow arrow function definitions passing to worker", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [
+      terser({
+        mangle: { properties: { regex: /^_/ } },
+        output: {
+          comments: (node, comment) => {
             if (comment.type === "comment2") {
               // multiline comment
               return /@preserve|@license|@cc_on|^!/i.test(comment.value);

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,4 @@
-const assert = require("assert");
 const { rollup } = require("rollup");
-const readFile = require("fs").readFileSync;
 const { terser } = require("../");
 
 test("minify", async () => {

--- a/transform.js
+++ b/transform.js
@@ -1,7 +1,7 @@
 const { minify } = require("terser");
 
 const transform = (code, optionsString) => {
-  const options = eval(optionsString);
+  const options = eval(`(${optionsString})`);
   const result = minify(code, options);
   if (result.error) {
     throw result.error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,17 +765,6 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
-  dependencies:
-    esprima "^3.1.3"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
-
 escodegen@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
@@ -1878,10 +1867,6 @@ kleur@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.1.tgz#4f5b313f5fa315432a400f19a24db78d451ede62"
 
-lave@^1.1.10:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/lave/-/lave-1.1.10.tgz#062207652c5502d7c6ff096c9de3995401f634d5"
-
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -2687,6 +2672,11 @@ semver@^5.4.1:
 semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+
+serialize-javascript@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
+  integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Unfortunately the introduction of the `lave` package broke the arrow functions within the options. So it is not as stable as I thought it would be.

But luckily by now `serialize-javascript` released a new [version 1.6.1](https://github.com/yahoo/serialize-javascript/releases/tag/v1.6.0) with the addition of complex object literals.

Because of that I was able to partially roll back my former PR #13 
I've added regression tests for all three cases now.

This PR should fix #27 and #24 