### PR TITLE
Added feat to write to different output file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ terser(options);
 
 Generates source maps and passes them to rollup. Defaults to `true`.
 
+`options.filename: string`
+
+If set, writes the minified output to this file, and leaves the regular output file unminified. Not set by default.
+
 `options.numWorkers: number`
 
 Amount of workers to spawn. Defaults to the number of CPUs minus 1.


### PR DESCRIPTION
I know in issue #29 you said you didn't want this feature added, but please hear me out.

I added this because I'm trying to port [Babylon.js](https://github.com/BabylonJS/Babylon.js) to Rollup. The core module alone takes 2 minutes for the UMD bundle, and the minified UMD bundle takes another 2 min and 30 seconds. I can majorly cut that down by only generating the bundle once and then just writing normal and minified to different files.

The **only** change is that `terser({ filename: "custom.js" })` will write to "custom.js" and leave the regular output file untouched. It's literally just a few extra lines of code (just adding an extra promise at the end), and all tests still pass.

Please consider this.
