### PR TITLE
feat: add support for filter by chunk files names

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,38 @@ Generates source maps and passes them to rollup. Defaults to `true`.
 
 Amount of workers to spawn. Defaults to the number of CPUs minus 1.
 
+
+`options.include: Array<string | RegExp> | string | RegExp`
+
+`options.exclude: Array<string | RegExp> | string | RegExp`
+
+Specifically include/exclude chunk files names (minimatch pattern, or array of minimatch patterns), By default all chunk files will be minify.
+
 ## Examples
+
+### include/exclude
+If you'd like that only some of the files will be minify, then you can filter by `include` and `exclude` to do this like so:
+
+```js
+// rollup.config.js
+import { terser } from "rollup-plugin-terser";
+
+export default {
+  input: "some.js",
+  output: [
+    { file: 'some.js' },
+    { file: 'some.min.js' },
+    { file: 'foo.min.js' },
+    { file: 'other.min.js' }
+  ],
+  plugins: [
+    terser({
+      include: /^.+\.min\.js$/, 
+      exclude: [ 'foo.min.js', 'other*' ]
+    })
+  ]
+};
+```
 
 ### Comments
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,17 @@ If you'd like that only some of the files will be minify, then you can filter by
 import { terser } from "rollup-plugin-terser";
 
 export default {
-  input: "some.js",
+  input: "index.js",
   output: [
-    { file: 'some.js' },
-    { file: 'some.min.js' },
-    { file: 'foo.min.js' },
-    { file: 'other.min.js' }
+    { file: 'lib.js', format: 'cjs' },
+    { file: 'lib.min.js', format: 'cjs' },
+    { file: 'lib.esm.js', format: 'es' },
+    { dir: '.', entryFileNames: 'lib-[format].js', format: 'iife'  }
   ],
   plugins: [
     terser({
-      include: /^.+\.min\.js$/, 
-      exclude: [ 'foo.min.js', 'other*' ]
+      include: [/^.+\.min\.js$/, '*esm*'], 
+      exclude: [ 'some*' ]
     })
   ]
 };

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function terser(userOptions = {}) {
   return {
     name: "terser",
 
-    renderChunk(code, { fileName }, outputOptions) {
-      if(!filter(fileName)){
+    renderChunk(code, chunk, outputOptions) {
+      if(!filter(chunk.fileName)){
         return null;
       }
 

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
 const serialize = require("serialize-javascript");
+const { createFilter } = require('rollup-pluginutils');
 
 function terser(userOptions = {}) {
   if (userOptions.sourceMap != null) {
     throw Error("sourceMap option is removed, use sourcemap instead");
   }
 
+  const filter = createFilter( userOptions.include, userOptions.exclude, { resolve: false } );
+
   return {
     name: "terser",
 
-    renderChunk(code, chunk, outputOptions) {
+    renderChunk(code, { fileName }, outputOptions) {
+      if(!filter(fileName)){
+        return null;
+      }
+
       if (!this.worker) {
         this.worker = new Worker(require.resolve("./transform.js"), {
           numWorkers: userOptions.numWorkers
@@ -26,7 +33,7 @@ function terser(userOptions = {}) {
         module: outputOptions.format === "es" || outputOptions.format === "esm"
       });
 
-      for (let key of ["sourcemap", "numWorkers"]) {
+      for (let key of ["include", "exclude", "sourcemap", "numWorkers"]) {
         if (normalizedOptions.hasOwnProperty(key)) {
           delete normalizedOptions[key];
         }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "jest-worker": "^24.6.0",
+    "rollup-pluginutils": "^2.8.1",
     "serialize-javascript": "^1.7.0",
     "terser": "^4.0.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -237,3 +237,52 @@ test("allow arrow function definitions passing to worker", async () => {
     '"use strict";window.a=5,window.a<3&&console.log(4);\n'
   );
 });
+
+test("allow to pass not string values to worker", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [terser({ mangle: { properties: { regex: /^_/ } } })]
+  });
+  const result = await bundle.generate({ format: "cjs" });
+  expect(result.output[0].code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+});
+
+test("include chunk file by string name", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [ terser({ include: 'some.js' }) ]
+  });
+
+  const result = await bundle.generate({ format: "es", file: 'some.js' });
+  const { code, map } = result.output[0];
+  expect(code).toBe(`window.a=5,window.a<3&&console.log(4);\n`);
+  expect(map).toBeFalsy();
+});
+
+test("exclude chunk file pattern name by minimatch pattern", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [ terser({ exclude: '*-cjs.js' }) ]
+  });
+  const result = await bundle.generate({ format: "cjs", entryFileNames: '[name]-[format].js' });
+  const { code, map } = result.output[0];
+
+  expect(code).toBe(`'use strict';\n\nwindow.a = 5;\n\nif (window.a < 3) {\n  console.log(4);\n}\n`);
+  expect(map).toBeFalsy();
+});
+
+test("include only one chunk file by regex", async () => {
+  const bundle = await rollup({
+    input: [ "test/fixtures/chunk-1.js", "test/fixtures/chunk-2.js" ],
+    plugins: [ terser({ include: /.+-1\.\w+/ }) ]
+  });
+  const result = await bundle.generate({ format: "es" });
+  const { 0: chunk1, 1: chunk2 } = result.output;
+
+  expect(chunk1.code).toBe(`console.log("chunk-1");\n`);
+  expect(chunk1.map).toBeFalsy();
+  expect(chunk2.code).toBe(`var chunk2 = 'chunk-2';\nconsole.log(chunk2);\n`);
+  expect(chunk2.map).toBeFalsy();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,6 +1055,11 @@ estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -2868,6 +2873,13 @@ rimraf@^2.6.2:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   dependencies:
     glob "^7.1.3"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup@^1.12.3:
   version "1.12.3"


### PR DESCRIPTION
add option to include and exclude chunk files.
```js
terser({
  include: [ 'some*', 'foo.js' ],
  exclude: /other.*/
})
```