### PR TITLE
Don't allow `sourceMap` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { Plugin } from 'rollup';
 import { MinifyOptions } from 'terser';
 
-export interface Options extends MinifyOptions {
+export interface Options extends Omit<MinifyOptions, "sourceMap"> {
 
 	/**
 	 * Specifically include/exclude chunk files names (minimatch pattern, or array of minimatch patterns), By default all chunk files will be minify.


### PR DESCRIPTION
Including the capital-M `sourceMap` option is an error, so we should exclude it from types.

Fixes #41 