### PR TITLE
chore: update serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/code-frame": "^7.0.0",
     "jest-worker": "^24.6.0",
     "rollup-pluginutils": "^2.8.1",
-    "serialize-javascript": "^1.7.0",
+    "serialize-javascript": "^2.1.1",
     "terser": "^4.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The currently used version of serialize-javascript has a XSS security vulnerability.
This is fixed in v2.1.1