### PR TITLE
Fix nameCache

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,13 @@ function terser(userOptions = {}) {
 
       result.then(handler, handler);
 
-      return result;
+      return result.then(result => {
+        if (result.nameCache) {
+          Object.assign(userOptions.nameCache, result.nameCache)
+        }
+
+        return result.code
+      });
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
 const serialize = require("serialize-javascript");
-const merge = require('lodash.merge');
 const { createFilter } = require('rollup-pluginutils');
 
 function terser(userOptions = {}) {
@@ -65,7 +64,28 @@ function terser(userOptions = {}) {
 
       return result.then(result => {
         if (result.nameCache) {
-          merge(userOptions.nameCache, result.nameCache)
+          let { vars, props } = userOptions.nameCache;
+
+          // only assign nameCache.vars if it was provided, and if terser produced values:
+          if (vars) {
+            const newVars = result.nameCache.vars && result.nameCache.vars.props;
+            if (newVars) {
+              vars.props = vars.props || {};
+              Object.assign(vars.props, newVars);
+            }
+          }
+
+          // support populating an empty nameCache object:
+          if (!props) {
+            props = userOptions.nameCache.props = {};
+          }
+
+          // merge updated props into original nameCache object:
+          const newProps = result.nameCache.props && result.nameCache.props.props;
+          if (newProps) {
+            props.props = props.props || {};
+            Object.assign(props.props, newProps);
+          }
         }
 
         return result.result

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
 const serialize = require("serialize-javascript");
+const merge = require('lodash.merge');
 const { createFilter } = require('rollup-pluginutils');
 
 function terser(userOptions = {}) {
@@ -64,7 +65,7 @@ function terser(userOptions = {}) {
 
       return result.then(result => {
         if (result.nameCache) {
-          Object.assign(userOptions.nameCache, result.nameCache)
+          merge(userOptions.nameCache, result.nameCache)
         }
 
         return result.result

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function terser(userOptions = {}) {
           Object.assign(userOptions.nameCache, result.nameCache)
         }
 
-        return result.code
+        return result.result
       });
     }
   };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/code-frame": "^7.0.0",
     "jest-worker": "^24.6.0",
     "rollup-pluginutils": "^2.8.1",
+    "lodash.merge": "^4.6.2",
     "serialize-javascript": "^1.7.0",
     "terser": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@babel/code-frame": "^7.0.0",
     "jest-worker": "^24.6.0",
     "rollup-pluginutils": "^2.8.1",
-    "lodash.merge": "^4.6.2",
     "serialize-javascript": "^1.7.0",
     "terser": "^4.1.0"
   },

--- a/test/fixtures/properties-and-locals.js
+++ b/test/fixtures/properties-and-locals.js
@@ -1,0 +1,9 @@
+function recurse(count) {
+	if (count > 0) return recurse(count - 1);
+	return count;
+}
+const obj = {
+	foo: 1,
+	_priv: 2
+};
+console.log(obj, recurse(10));

--- a/test/fixtures/properties.js
+++ b/test/fixtures/properties.js
@@ -1,0 +1,5 @@
+const obj = {
+	foo: 1,
+	_priv: 2
+};
+console.log(obj);

--- a/test/test.js
+++ b/test/test.js
@@ -286,3 +286,119 @@ test("include only one chunk file by regex", async () => {
   expect(chunk2.code).toBe(`var chunk2 = 'chunk-2';\nconsole.log(chunk2);\n`);
   expect(chunk2.map).toBeFalsy();
 });
+
+test("terser accepts the nameCache option", async () => {
+  const nameCache = {
+    props: {
+      props: {
+        $_priv: 'custom'
+      }
+    }
+  };
+  const bundle = await rollup({
+    input: "test/fixtures/properties.js",
+    plugins: [terser({
+      mangle: {
+        properties: {
+          regex: /^_/
+        }
+      },
+      nameCache
+    })]
+  });
+  const result = await bundle.generate({ format: "es" });
+  expect(result.output[0].code.trim()).toEqual(`console.log({foo:1,custom:2});`);
+});
+
+test("terser updates the nameCache object", async () => {
+  const nameCache = {
+    props: {
+      props: {
+        $_priv: 'f'
+      }
+    }
+  };
+  const props = nameCache.props;
+  const bundle = await rollup({
+    input: "test/fixtures/properties.js",
+    plugins: [terser({
+      mangle: {
+        properties: {
+          regex: /./
+        }
+      },
+      nameCache
+    })]
+  });
+  const result = await bundle.generate({ format: "es" });
+  expect(result.output[0].code.trim()).toEqual(`console.log({o:1,f:2});`);
+  expect(nameCache.props).toBe(props);
+  expect(nameCache).toEqual({
+    props: {
+      props: {
+        $_priv: 'f',
+        $foo: 'o'
+      }
+    }
+  });
+});
+
+test("omits populates an empty nameCache object", async () => {
+  const nameCache = {};
+  const bundle = await rollup({
+    input: "test/fixtures/properties-and-locals.js",
+    plugins: [terser({
+      mangle: {
+        properties: {
+          regex: /./
+        }
+      },
+      nameCache
+    })]
+  });
+  const result = await bundle.generate({ format: "es" });
+  expect(result.output[0].code.trim()).toEqual(`console.log({o:1,i:2},function o(n){return n>0?o(n-1):n}(10));`);
+  expect(nameCache).toEqual({
+    props: {
+      props: {
+        $_priv: 'i',
+        $foo: 'o'
+      }
+    }
+  });
+});
+
+// Note: nameCache.vars never gets populated, but this is a Terser issue.
+// Here we're just testing that an empty vars object doesn't get added to nameCache if it wasn't there previously.
+test("terser preserve vars in nameCache when provided", async () => {
+  const nameCache = {
+    vars: {
+      props: {}
+    }
+  };
+  const bundle = await rollup({
+    input: "test/fixtures/properties-and-locals.js",
+    plugins: [terser({
+      mangle: {
+        properties: {
+          regex: /./
+        }
+      },
+      nameCache
+    })]
+  });
+  const result = await bundle.generate({ format: "es" });
+  expect(result.output[0].code.trim()).toEqual(`console.log({o:1,i:2},function o(n){return n>0?o(n-1):n}(10));`);
+  expect(nameCache).toEqual({
+    props: {
+      props: {
+        $_priv: 'i',
+        $foo: 'o'
+      }
+    },
+    vars: {
+      props: {}
+    }
+  });
+});
+

--- a/transform.js
+++ b/transform.js
@@ -6,7 +6,7 @@ const transform = (code, optionsString) => {
   if (result.error) {
     throw result.error;
   } else {
-    return result;
+    return { result, nameCache: options.nameCache };
   }
 };
 


### PR DESCRIPTION
This fix for #61 incorporates @samdenty's great work from #47, but replaces `lodash.merge` with a more specific object merging based on how Terser's nameCache works.  I also added tests to cover both nameCache usage and the fixed nameCache mutation.

As with Sam's approach, this avoids ever removing mapped properties from nameCache, since doing so creates a race condition in cases where Rollup is producing multiple bundles. For Microbundle's use-case this seems like an acceptable trade-off, and it's certainly an improvement over nameCache not being mutated.

/cc @samdenty @TrySound 