### PR TITLE
Testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; EditorConfig file: https://EditorConfig.org
+; Install the "EditorConfig" plugin into your editor to use
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,40 @@ test("minify", async () => {
   expect(output.map).toBeFalsy();
 });
 
+test("minify with `numWorkers` option", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [terser({
+      numWorkers: 2
+    })],
+  });
+  const result = await bundle.generate({ format: "cjs" });
+  expect(result.output).toHaveLength(1);
+  const [output] = result.output;
+  expect(output.code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+  expect(output.map).toBeFalsy();
+});
+
+test("minify with empty `nameCache.vars`", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [terser({
+      nameCache: {
+        vars: {}
+      }
+    })],
+  });
+  const result = await bundle.generate({ format: "cjs" });
+  expect(result.output).toHaveLength(1);
+  const [output] = result.output;
+  expect(output.code).toEqual(
+    '"use strict";window.a=5,window.a<3&&console.log(4);\n'
+  );
+  expect(output.map).toBeFalsy();
+});
+
 test("minify via terser options", async () => {
   const bundle = await rollup({
     input: "test/fixtures/empty.js",


### PR DESCRIPTION
FWIW, in checking out your tests, including `jest --coverage`, I saw there were a few small uncovered else cases (there is still one more else case after this, and `jest`'s coverage doesn't seem to pick up the `transform` calls).

The `.editorconfig` is useful to allow proper setting of indent ahead of time in the IDE without having to toggle config.

And the `.gitignore` change is since running `jest --coverage` adds files to `coverage`.

Anyways, for what it's worth--wasn't digging too deeply, just in case you want...