### PR TITLE
Bumping terser to 5.2.0 to enable optional chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/code-frame": "^7.10.4",
     "jest-worker": "^26.2.1",
     "serialize-javascript": "^4.0.0",
-    "terser": "^5.0.0"
+    "terser": "^5.2.0"
   },
   "peerDependencies": {
     "rollup": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3230,10 +3230,10 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.0.0.tgz#269640e4e92f15d628de1e5f01c4c61e1ba3d765"
-  integrity sha512-olH2DwGINoSuEpSGd+BsPuAQaA3OrHnHnFL/rDB2TVNc3srUbz/rq/j2BlF4zDXI+JqAvGr86bIm1R2cJgZ3FA==
+terser@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.2.0.tgz#e547d0b20926b321d3e524bf9e5bc1b10ba2f360"
+  integrity sha512-nZ9TWhBznZdlww3borgJyfQDrxzpgd0RlRNoxR63tMVry01lIH/zKQDTTiaWRMGowydfvSHMgyiGyn6A9PSkCQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
As stated on https://github.com/terser/terser/issues/567#issuecomment-675583347 Optional Chaining is now available so I decided to bump terser because I have it disabled at the moment on some personal project because it was breaking for this particular case.