### PR TITLE
fix(types): remove invalid `sourcemap` option

### DIFF
--- a/rollup-plugin-terser.d.ts
+++ b/rollup-plugin-terser.d.ts
@@ -6,13 +6,6 @@ export interface Options extends Omit<MinifyOptions, "sourceMap"> {
    * Amount of workers to spawn. Defaults to the number of CPUs minus 1.
    */
   numWorkers?: number;
-
-  /**
-   * Generates source maps and passes them to rollup.
-   *
-   * @default true
-   */
-  sourcemap?: boolean;
 }
 
 export declare function terser(options?: Options): Plugin;


### PR DESCRIPTION
Throws error if defined -- so no point in exposing it within the definitions