### PR TITLE
Enable worker_threads where available

### DIFF
--- a/rollup-plugin-terser.js
+++ b/rollup-plugin-terser.js
@@ -21,6 +21,7 @@ function terser(userOptions = {}) {
       if (!this.worker) {
         this.worker = new Worker(require.resolve("./transform.js"), {
           numWorkers: userOptions.numWorkers,
+          enableWorkerThreads: true,
         });
         this.numOfBundles = 0;
       }


### PR DESCRIPTION
It would be nice to have this run in threads rather than child processes on versions of Node with `worker_threads`. Jest-worker supports automatically detecting and using threads, but as per the [docs](https://github.com/facebook/jest/tree/main/packages/jest-worker#enableworkerthreads-boolean-optional), will only do so when passed `enableWorkerThreads:true`:

> `jest-worker` will automatically detect if `worker_threads` are available, **but will not use them unless passed `enableWorkerThreads: true`**.